### PR TITLE
[Refactor/article] 뉴스 기사 view 등록

### DIFF
--- a/src/main/java/com/sprint5team/monew/domain/article/dto/ArticleCommentCount.java
+++ b/src/main/java/com/sprint5team/monew/domain/article/dto/ArticleCommentCount.java
@@ -1,0 +1,8 @@
+package com.sprint5team.monew.domain.article.dto;
+
+import java.util.UUID;
+
+public interface ArticleCommentCount {
+    UUID getArticleId();
+    Long getCount();
+}

--- a/src/main/java/com/sprint5team/monew/domain/article/dto/ArticleViewDto.java
+++ b/src/main/java/com/sprint5team/monew/domain/article/dto/ArticleViewDto.java
@@ -10,11 +10,11 @@ import java.util.UUID;
  * @param articleId 기사 ID
  * @param source 출처
  * @param sourceUrl 원본 기사 URL
- * @param title 제목
- * @param publishDate 기사 날짜
- * @param summary 요약
- * @param commentCount 댓글 수
- * @param viewCount 조회 수
+ * @param articleTitle 제목
+ * @param articlePublishDate 기사 날짜
+ * @param articleSummary 요약
+ * @param articleCommentCount 댓글 수
+ * @param articleViewCount 조회 수
  */
 public record ArticleViewDto(
         UUID id,
@@ -23,10 +23,10 @@ public record ArticleViewDto(
         UUID articleId,
         String source,
         String sourceUrl,
-        String title,
-        Instant publishDate,
-        String summary,
-        long commentCount,
-        long viewCount
+        String articleTitle,
+        Instant articlePublishDate,
+        String articleSummary,
+        long articleCommentCount,
+        long articleViewCount
 ) {
 }

--- a/src/main/java/com/sprint5team/monew/domain/article/mapper/ArticleViewMapper.java
+++ b/src/main/java/com/sprint5team/monew/domain/article/mapper/ArticleViewMapper.java
@@ -12,13 +12,14 @@ public interface ArticleViewMapper {
 
     @Mapping(source = "user.id", target = "viewedBy")
     @Mapping(source = "article.id", target = "articleId")
-    @Mapping(source = "article.title", target = "title")
-    @Mapping(source = "article.summary", target = "summary")
+    @Mapping(source = "article.title", target = "articleTitle")
+    @Mapping(source = "article.summary", target = "articleSummary")
     @Mapping(source = "article.source", target = "source")
     @Mapping(source = "article.sourceUrl", target = "sourceUrl")
-    @Mapping(source = "article.originalDateTime", target = "publishDate")
+    @Mapping(source = "article.originalDateTime", target = "articlePublishDate")
     @Mapping(source = "articleCount.createdAt", target = "createdAt")
     @Mapping(source = "articleCount.id", target = "id")
-    // commentCount, viewCount는 수동 계산 필요
-    ArticleViewDto toDto(Article article, User user, ArticleCount articleCount);
+    @Mapping(source = "viewedCount", target = "articleViewCount")
+    @Mapping(source = "commentCount", target = "articleCommentCount")
+    ArticleViewDto toDto(Article article, User user, ArticleCount articleCount, Long viewedCount, Long commentCount);
 }

--- a/src/main/java/com/sprint5team/monew/domain/article/service/ArticleServiceImpl.java
+++ b/src/main/java/com/sprint5team/monew/domain/article/service/ArticleServiceImpl.java
@@ -51,8 +51,10 @@ public class ArticleServiceImpl implements ArticleService {
         if (articleCount.isEmpty()) {
             articleCountRepository.save(new ArticleCount(article,  user));
         }
-
-        return articleViewMapper.toDto(article, user, articleCount.orElse(null));
+        Map<UUID, Long> viewCount = articleCountRepository.countViewByArticleIds(List.of(articleId));
+        Map<UUID, Long> commentCount = commentRepository.countByArticleIds(List.of(articleId)).stream()
+                .collect(Collectors.toMap(ArticleCommentCount::getArticleId, ArticleCommentCount::getCount));
+        return articleViewMapper.toDto(article, user, articleCount.orElse(null), viewCount.getOrDefault(articleId, 0L), commentCount.getOrDefault(articleId, 0L));
     }
 
     @Override

--- a/src/main/java/com/sprint5team/monew/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/sprint5team/monew/domain/comment/repository/CommentRepository.java
@@ -1,10 +1,21 @@
 package com.sprint5team.monew.domain.comment.repository;
 
+import com.sprint5team.monew.domain.article.dto.ArticleCommentCount;
 import com.sprint5team.monew.domain.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
 
+    @Query("""
+        SELECT c.article.id AS articleId, COUNT(c) AS count
+        FROM Comment c
+        WHERE c.article.id IN :articleIds
+        GROUP BY c.article.id
+    """)
+    List<ArticleCommentCount> countByArticleIds(@Param("articleIds") List<UUID> articleIds);
 }

--- a/src/test/java/com/sprint5team/monew/service/article/ArticleServiceTest.java
+++ b/src/test/java/com/sprint5team/monew/service/article/ArticleServiceTest.java
@@ -90,7 +90,7 @@ public class ArticleServiceTest {
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
         given(articleCountRepository.findByUserIdAndArticleId(userId, articleId)).willReturn(Optional.empty());
-        given(articleViewMapper.toDto(any(), any(), any())).willReturn(articleViewDto);
+        given(articleViewMapper.toDto(any(), any(), any(), any(), any())).willReturn(articleViewDto);
 
         // when
         ArticleViewDto result = articleService.saveArticleView(articleId, userId);


### PR DESCRIPTION
## 📌 작업 개요
- 어떤 기능을 개발했는지 간단 요약
- 예: 직원 등록 기능 구현 / 부서별 조회 API 리팩토링 등
- 뉴스 기사 view 등록 시 반환 dto의 commentCount, viewCount default 값 0 수정
## 🔧 주요 작업 내용
- [x] ArticleViewDto 필드 네임 swagger api와 맞게 수정
- [x] ArticleViewMapper @Mapping 어노테이션 이용하여 commentCount, viewCount 매핑
- [x] ArticleService.saveArticleView()
  - [x] ArticleCountRepository, CommentRepository 이용하여 각 카운트 집계   

## ✅ 확인 사항
- [x] 로컬 서버에서 정상 동작 확인
- [x] 테스트 코드 작성 또는 수동 테스트 완료
- [ ] Swagger 문서 반영 확인

## 🧪 테스트 방법
- Postman, Swagger UI 등을 통해 직접 확인한 테스트 내용
- ex: "지수 등록 API 호출 시 정상 응답 및 DB 반영 확인"
- local 서버 실행 후 Postman 요청 시 정상 응답 확인
<img width="2516" height="2272" alt="스크린샷 2025-07-16 11 42 31" src="https://github.com/user-attachments/assets/19977701-5863-4383-a502-54ba3cece5e7" />

## 📎 기타 참고 사항
- 추가 논의가 필요한 사항
- 관련 이슈, API 문서 링크 등
close #41
## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션을 준수했습니다. 
- [x] 변경 사항에 대한 테스트를 수행했습니다.
