### PR TITLE
[Feature/article] 뉴스 기사 물리 삭제

### DIFF
--- a/src/main/java/com/sprint5team/monew/domain/article/controller/ArticleController.java
+++ b/src/main/java/com/sprint5team/monew/domain/article/controller/ArticleController.java
@@ -83,4 +83,14 @@ public class ArticleController {
                 .status(HttpStatus.OK)
                 .body(articleRestoreResultDto);
     }
+
+    @DeleteMapping("/{articleId}")
+    public ResponseEntity<Void> softDeleteArticle(
+            @PathVariable UUID articleId,
+            @RequestHeader("MoNew-Request-User-ID") UUID userId
+    ) {
+        articleService.softDeleteArticle(articleId);
+
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/sprint5team/monew/domain/article/controller/ArticleController.java
+++ b/src/main/java/com/sprint5team/monew/domain/article/controller/ArticleController.java
@@ -93,4 +93,13 @@ public class ArticleController {
 
         return ResponseEntity.noContent().build();
     }
+
+    @DeleteMapping("/{articleId}/hard")
+    public ResponseEntity<Void> hardDeleteArticle(
+            @PathVariable UUID articleId,
+            @RequestHeader("MoNew-Request-User-ID") UUID userId
+    ) {
+        articleService.hardDeleteArticle(articleId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/sprint5team/monew/domain/article/controller/ArticleController.java
+++ b/src/main/java/com/sprint5team/monew/domain/article/controller/ArticleController.java
@@ -6,11 +6,13 @@ import com.sprint5team.monew.domain.article.dto.CursorPageFilter;
 import com.sprint5team.monew.domain.article.dto.CursorPageResponseArticleDto;
 import com.sprint5team.monew.domain.article.service.ArticleService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -37,8 +39,8 @@ public class ArticleController {
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) UUID interestId,
             @RequestParam(required = false) List<String> sourceIn,
-            @RequestParam(required = false) Instant publishDateFrom,
-            @RequestParam(required = false) Instant publishDateTo,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime publishDateFrom,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime publishDateTo,
             @RequestParam String orderBy,
             @RequestParam String direction,
             @RequestParam(required = false) String cursor,

--- a/src/main/java/com/sprint5team/monew/domain/article/dto/CursorPageFilter.java
+++ b/src/main/java/com/sprint5team/monew/domain/article/dto/CursorPageFilter.java
@@ -1,6 +1,7 @@
 package com.sprint5team.monew.domain.article.dto;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -8,8 +9,8 @@ public record CursorPageFilter (
         String keyword,
         UUID interestId,
         List<String> sourceIn,
-        Instant publishDateFrom,
-        Instant publishDateTo,
+        LocalDateTime publishDateFrom,
+        LocalDateTime publishDateTo,
         String orderBy,
         String direction,
         String cursor,

--- a/src/main/java/com/sprint5team/monew/domain/article/entity/Article.java
+++ b/src/main/java/com/sprint5team/monew/domain/article/entity/Article.java
@@ -48,4 +48,8 @@ public class Article extends BaseEntity {
         this.originalDateTime = originalDateTime;
         this.isDeleted = false;
     }
+
+    public void softDelete() {
+        isDeleted = true;
+    }
 }

--- a/src/main/java/com/sprint5team/monew/domain/article/repository/ArticleCountRepository.java
+++ b/src/main/java/com/sprint5team/monew/domain/article/repository/ArticleCountRepository.java
@@ -13,4 +13,6 @@ public interface ArticleCountRepository extends JpaRepository<ArticleCount, UUID
     Optional<ArticleCount> findByUserIdAndArticleId(UUID userId, UUID articleId);
 
     List<ArticleCount> findAllByUserIdAndArticleId(UUID id, UUID id1);
+
+    List<ArticleCount> findByArticleId(UUID articleId);
 }

--- a/src/main/java/com/sprint5team/monew/domain/article/repository/ArticleCustomRepositoryImpl.java
+++ b/src/main/java/com/sprint5team/monew/domain/article/repository/ArticleCustomRepositoryImpl.java
@@ -30,6 +30,8 @@ public class ArticleCustomRepositoryImpl implements ArticleCustomRepository {
 
         BooleanBuilder builder = new BooleanBuilder();
 
+        builder.and(article.isDeleted.isFalse());
+
         // 검색어 필터 (제목 또는 요약)
         if (filter.keyword() != null) {
             builder.andAnyOf(
@@ -120,6 +122,8 @@ public class ArticleCustomRepositoryImpl implements ArticleCustomRepository {
         QArticle article = QArticle.article;
 
         BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(article.isDeleted.isFalse());
 
         // 검색어 필터 (제목 또는 요약)
         if (filter.keyword() != null) {

--- a/src/main/java/com/sprint5team/monew/domain/article/repository/ArticleCustomRepositoryImpl.java
+++ b/src/main/java/com/sprint5team/monew/domain/article/repository/ArticleCustomRepositoryImpl.java
@@ -12,6 +12,7 @@ import com.sprint5team.monew.domain.comment.entity.QComment;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.ZoneId;
 import java.util.List;
 
 @Repository
@@ -47,13 +48,13 @@ public class ArticleCustomRepositoryImpl implements ArticleCustomRepository {
 
         // 날짜 필터
         if (filter.publishDateFrom() != null && filter.publishDateTo() != null) {
-            builder.and(article.createdAt.between(filter.publishDateFrom(), filter.publishDateTo()));
+            builder.and(article.createdAt.between(filter.publishDateFrom().atZone(ZoneId.of("Asia/Seoul")).toInstant(), filter.publishDateTo().atZone(ZoneId.of("Asia/Seoul")).toInstant()));
         } else {
             if (filter.publishDateFrom() != null) {
-                builder.and(article.createdAt.after(filter.publishDateFrom()));
+                builder.and(article.createdAt.after(filter.publishDateFrom().atZone(ZoneId.of("Asia/Seoul")).toInstant()));
             }
             if (filter.publishDateTo() != null) {
-                builder.and(article.createdAt.before(filter.publishDateTo()));
+                builder.and(article.createdAt.before(filter.publishDateTo().atZone(ZoneId.of("Asia/Seoul")).toInstant()));
             }
         }
 
@@ -140,13 +141,13 @@ public class ArticleCustomRepositoryImpl implements ArticleCustomRepository {
 
         // 날짜 필터
         if (filter.publishDateFrom() != null && filter.publishDateTo() != null) {
-            builder.and(article.createdAt.between(filter.publishDateFrom(), filter.publishDateTo()));
+            builder.and(article.createdAt.between(filter.publishDateFrom().atZone(ZoneId.of("Asia/Seoul")).toInstant(), filter.publishDateTo().atZone(ZoneId.of("Asia/Seoul")).toInstant()));
         } else {
             if (filter.publishDateFrom() != null) {
-                builder.and(article.createdAt.after(filter.publishDateFrom()));
+                builder.and(article.createdAt.after(filter.publishDateFrom().atZone(ZoneId.of("Asia/Seoul")).toInstant()));
             }
             if (filter.publishDateTo() != null) {
-                builder.and(article.createdAt.before(filter.publishDateTo()));
+                builder.and(article.createdAt.before(filter.publishDateTo().atZone(ZoneId.of("Asia/Seoul")).toInstant()));
             }
         }
 

--- a/src/main/java/com/sprint5team/monew/domain/article/service/ArticleService.java
+++ b/src/main/java/com/sprint5team/monew/domain/article/service/ArticleService.java
@@ -19,4 +19,6 @@ public interface ArticleService {
     ArticleRestoreResultDto restoreArticle(Instant from, Instant to);
 
     void softDeleteArticle(UUID articleId);
+
+    void hardDeleteArticle(UUID articleId);
 }

--- a/src/main/java/com/sprint5team/monew/domain/article/service/ArticleService.java
+++ b/src/main/java/com/sprint5team/monew/domain/article/service/ArticleService.java
@@ -17,4 +17,6 @@ public interface ArticleService {
     List<String> getSources();
 
     ArticleRestoreResultDto restoreArticle(Instant from, Instant to);
+
+    void softDeleteArticle(UUID articleId);
 }

--- a/src/main/java/com/sprint5team/monew/domain/article/service/ArticleServiceImpl.java
+++ b/src/main/java/com/sprint5team/monew/domain/article/service/ArticleServiceImpl.java
@@ -186,4 +186,9 @@ public class ArticleServiceImpl implements ArticleService {
             articleRepository.save(article);
         }
     }
+
+    @Override
+    public void hardDeleteArticle(UUID articleId) {
+
+    }
 }

--- a/src/main/java/com/sprint5team/monew/domain/article/service/ArticleServiceImpl.java
+++ b/src/main/java/com/sprint5team/monew/domain/article/service/ArticleServiceImpl.java
@@ -177,6 +177,13 @@ public class ArticleServiceImpl implements ArticleService {
 
     @Override
     public void softDeleteArticle(UUID articleId) {
+        Article article = articleRepository.findById(articleId).orElseThrow(
+                ArticleNotFoundException::new
+        );
 
+        if (!article.isDeleted()) {
+            article.softDelete();
+            articleRepository.save(article);
+        }
     }
 }

--- a/src/main/java/com/sprint5team/monew/domain/article/service/ArticleServiceImpl.java
+++ b/src/main/java/com/sprint5team/monew/domain/article/service/ArticleServiceImpl.java
@@ -174,4 +174,9 @@ public class ArticleServiceImpl implements ArticleService {
                 restoredIds.size()
         );
     }
+
+    @Override
+    public void softDeleteArticle(UUID articleId) {
+
+    }
 }

--- a/src/main/java/com/sprint5team/monew/domain/article/service/ArticleServiceImpl.java
+++ b/src/main/java/com/sprint5team/monew/domain/article/service/ArticleServiceImpl.java
@@ -10,6 +10,7 @@ import com.sprint5team.monew.domain.article.mapper.ArticleMapper;
 import com.sprint5team.monew.domain.article.mapper.ArticleViewMapper;
 import com.sprint5team.monew.domain.article.repository.ArticleCountRepository;
 import com.sprint5team.monew.domain.article.repository.ArticleRepository;
+import com.sprint5team.monew.domain.comment.entity.Comment;
 import com.sprint5team.monew.domain.comment.repository.CommentRepository;
 import com.sprint5team.monew.domain.interest.entity.Interest;
 import com.sprint5team.monew.domain.interest.repository.InterestRepository;
@@ -189,6 +190,14 @@ public class ArticleServiceImpl implements ArticleService {
 
     @Override
     public void hardDeleteArticle(UUID articleId) {
+        articleRepository.findById(articleId).orElseThrow(ArticleNotFoundException::new);
 
+        List<Comment> comments = commentRepository.findByArticleId(articleId);
+
+        List<ArticleCount> articleViews = articleCountRepository.findByArticleId(articleId);
+
+        commentRepository.deleteAll(comments);
+        articleCountRepository.deleteAll(articleViews);
+        articleRepository.deleteById(articleId);
     }
 }

--- a/src/main/java/com/sprint5team/monew/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/sprint5team/monew/domain/comment/repository/CommentRepository.java
@@ -18,4 +18,6 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
         GROUP BY c.article.id
     """)
     List<ArticleCommentCount> countByArticleIds(@Param("articleIds") List<UUID> articleIds);
+
+    List<Comment> findByArticleId(UUID articleId);
 }

--- a/src/test/java/com/sprint5team/monew/controller/article/ArticleControllerTest.java
+++ b/src/test/java/com/sprint5team/monew/controller/article/ArticleControllerTest.java
@@ -158,4 +158,18 @@ public class ArticleControllerTest {
                 .header("MoNew-Request-User-ID", userId.toString()))
                 .andExpect(status().isNoContent());
     }
+
+    @Test
+    void 뉴스_기사_물리_삭제_API가_정상적으로_동작한다() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID articleId = UUID.randomUUID();
+
+        doNothing().when(articleService).hardDeleteArticle(articleId);
+
+        // when & then
+        mockMvc.perform(delete("/api/articles/{articleId}/hard", articleId)
+                        .header("MoNew-Request-User-ID", userId.toString()))
+                .andExpect(status().isNoContent());
+    }
 }

--- a/src/test/java/com/sprint5team/monew/controller/article/ArticleControllerTest.java
+++ b/src/test/java/com/sprint5team/monew/controller/article/ArticleControllerTest.java
@@ -22,8 +22,8 @@ import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -143,5 +143,19 @@ public class ArticleControllerTest {
                 .andExpect(jsonPath("$.restoredArticleIds.length()").value(4))
                 .andExpect(jsonPath("$.restoredArticleIds[0]").value("ba4b516e-3ab3-44ae-aa9d-713d29911e50"))
                 .andExpect(jsonPath("$.restoredArticleCount").value(4));
+    }
+
+    @Test
+    void 뉴스_기사_논리_삭제_API가_정상적으로_동작한다() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID articleId = UUID.randomUUID();
+
+        doNothing().when(articleService).softDeleteArticle(articleId, userId);
+
+        // when & then
+        mockMvc.perform(delete("/api/articles/{articleId}", articleId)
+                .header("MoNew-Request-User-ID", userId.toString()))
+                .andExpect(status().isNoContent());
     }
 }

--- a/src/test/java/com/sprint5team/monew/controller/article/ArticleControllerTest.java
+++ b/src/test/java/com/sprint5team/monew/controller/article/ArticleControllerTest.java
@@ -151,7 +151,7 @@ public class ArticleControllerTest {
         UUID userId = UUID.randomUUID();
         UUID articleId = UUID.randomUUID();
 
-        doNothing().when(articleService).softDeleteArticle(articleId, userId);
+        doNothing().when(articleService).softDeleteArticle(articleId);
 
         // when & then
         mockMvc.perform(delete("/api/articles/{articleId}", articleId)

--- a/src/test/java/com/sprint5team/monew/integration/article/ArticleIntegrationTest.java
+++ b/src/test/java/com/sprint5team/monew/integration/article/ArticleIntegrationTest.java
@@ -6,6 +6,8 @@ import com.sprint5team.monew.domain.article.entity.ArticleCount;
 import com.sprint5team.monew.domain.article.repository.ArticleCountRepository;
 import com.sprint5team.monew.domain.article.repository.ArticleRepository;
 import com.sprint5team.monew.domain.article.service.ArticleService;
+import com.sprint5team.monew.domain.comment.entity.Comment;
+import com.sprint5team.monew.domain.comment.repository.CommentRepository;
 import com.sprint5team.monew.domain.interest.entity.Interest;
 import com.sprint5team.monew.domain.interest.repository.InterestRepository;
 import com.sprint5team.monew.domain.keyword.entity.Keyword;
@@ -21,6 +23,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -38,6 +41,7 @@ public class ArticleIntegrationTest {
     @Autowired private UserRepository userRepository;
     @Autowired private KeywordRepository keywordRepository;
     @Autowired private InterestRepository interestRepository;
+    @Autowired private CommentRepository commentRepository;
 
     private User user;
 
@@ -120,8 +124,8 @@ public class ArticleIntegrationTest {
                 null,
                 interest.getId(),
                 Arrays.asList("NAVER"),
-                Instant.parse("2025-07-01T00:00:00Z"),
-                Instant.parse("2025-07-16T00:00:00Z"),
+                LocalDateTime.parse("2025-07-01T00:00:00"),
+                LocalDateTime.parse("2025-07-16T00:00:00"),
                 "publishDate",
                 "DESC",
                 null,
@@ -176,5 +180,36 @@ public class ArticleIntegrationTest {
         // then
         Article updated = articleRepository.findById(article2.getId()).orElseThrow();
         assertThat(updated.isDeleted()).isTrue();
+    }
+
+    @Test
+    void 주어진_ID로_뉴스기사를_물리_삭제_할_수_있다() {
+        // given
+        Article article1 = new Article("NAVER", "https://a.com", "AI 혁신", "미래 변화", false, Instant.now(), Instant.now());
+        Article article2 = new Article("NAVER", "https://b.com", "블록체인과 사회", "IT 기술", false, Instant.now(), Instant.now());
+        Article article3 = new Article("한국경제", "https://c.com", "일반 뉴스", "정치 이슈", false, Instant.now(), Instant.now());
+
+        articleRepository.save(article1);
+        articleRepository.save(article2);
+        articleRepository.save(article3);
+        articleRepository.flush();
+
+        Comment comment = new Comment(article2, user, "test 댓글");
+        commentRepository.save(comment);
+        ArticleCount viewCount = new ArticleCount(article2, user);
+        articleCountRepository.save(viewCount);
+
+        // when
+        articleService.hardDeleteArticle(article2.getId());
+
+        // then
+        List<Comment> comments = commentRepository.findByArticleId(article2.getId());
+        assertThat(comments).isEmpty();
+
+        List<ArticleCount> views = articleCountRepository.findByArticleId(article2.getId());
+        assertThat(views).isEmpty();
+
+        assertThat(commentRepository.findById(comment.getId())).isEmpty();
+        assertThat(articleCountRepository.findById(article2.getId())).isEmpty();
     }
 }

--- a/src/test/java/com/sprint5team/monew/integration/article/ArticleIntegrationTest.java
+++ b/src/test/java/com/sprint5team/monew/integration/article/ArticleIntegrationTest.java
@@ -157,4 +157,24 @@ public class ArticleIntegrationTest {
         assertThat(sources).hasSize(2);
         assertThat(sources.get(1)).isEqualTo("한국경제");
     }
+
+    @Test
+    void 주어진_ID로_뉴스기사를_논리_삭제_할_수_있다() {
+        // given
+        Article article1 = new Article("NAVER", "https://a.com", "AI 혁신", "미래 변화", false, Instant.now(), Instant.now());
+        Article article2 = new Article("NAVER", "https://b.com", "블록체인과 사회", "IT 기술", false, Instant.now(), Instant.now());
+        Article article3 = new Article("한국경제", "https://c.com", "일반 뉴스", "정치 이슈", false, Instant.now(), Instant.now());
+
+        articleRepository.save(article1);
+        articleRepository.save(article2);
+        articleRepository.save(article3);
+        articleRepository.flush();
+
+        // when
+        articleService.softDeleteArticle(article2.getId());
+
+        // then
+        Article updated = articleRepository.findById(article2.getId()).orElseThrow();
+        assertThat(updated.isDeleted()).isTrue();
+    }
 }

--- a/src/test/java/com/sprint5team/monew/repository/article/ArticleRepositoryTest.java
+++ b/src/test/java/com/sprint5team/monew/repository/article/ArticleRepositoryTest.java
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -83,8 +84,8 @@ public class ArticleRepositoryTest {
                 "AI",
                 interest.getId(),
                 Arrays.asList("NAVER"),
-                Instant.parse("2025-07-12T00:00:00Z"),
-                Instant.parse("2025-07-13T00:00:00Z"),
+                LocalDateTime.parse("2025-07-12T00:00:00"),
+                LocalDateTime.parse("2025-07-13T00:00:00"),
                 "publishDate",
                 "ASC",
                 null,

--- a/src/test/java/com/sprint5team/monew/service/article/ArticleServiceTest.java
+++ b/src/test/java/com/sprint5team/monew/service/article/ArticleServiceTest.java
@@ -239,22 +239,20 @@ public class ArticleServiceTest {
     @Test
     void 주어진_뉴스기사_ID로_뉴스기사를_논리삭제_할_수_있다() {
         // given
-        List<Article> articles = List.of(
-                new Article("NAVER", "https://...1", "AI", "경제", false, Instant.now(), Instant.now()),
-                new Article("한국경제", "https://...2", "AI2", "경제2", false, Instant.now(), Instant.now())
-        );
+        Article article1 = new Article("NAVER", "https://...1", "AI", "경제", false, Instant.now(), Instant.now());
+        Article article2 = new Article("한국경제", "https://...2", "AI2", "경제2", false, Instant.now(), Instant.now());
         UUID id1 = UUID.fromString("3b98b117-369e-4c36-a44d-7eef0a341d67");
         UUID id2 = UUID.fromString("ba4b516e-3ab3-44ae-aa9d-713d29911e50");
-        ReflectionTestUtils.setField(articles.get(0), "id", id1);
-        ReflectionTestUtils.setField(articles.get(1), "id", id2);
+        ReflectionTestUtils.setField(article1, "id", id1);
+        ReflectionTestUtils.setField(article2, "id", id2);
 
-        given(articleRepository.findById(id2)).willReturn(Optional.of(articles.get(1)));
+        given(articleRepository.findById(id2)).willReturn(Optional.of(article2));
 
         // when
-        articleService.softDeleteArticle(id2);
+        articleService.softDeleteArticle(article2.getId());
 
         // then
         assertThat(article2.isDeleted()).isTrue();
-        verify(articleRepository).save(articles.get(1));
+        verify(articleRepository).save(article2);
     }
 }

--- a/src/test/java/com/sprint5team/monew/service/article/ArticleServiceTest.java
+++ b/src/test/java/com/sprint5team/monew/service/article/ArticleServiceTest.java
@@ -30,6 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -116,8 +117,8 @@ public class ArticleServiceTest {
                 "AI",
                 interest.getId(),
                 Arrays.asList("NAVER", "한국경제"),
-                Instant.now(),
-                Instant.now(),
+                LocalDateTime.now(),
+                LocalDateTime.now(),
                 "publishDate",
                 "ASC",
                 null,
@@ -269,15 +270,16 @@ public class ArticleServiceTest {
         Comment comment = new Comment(article, user, "test 댓글");
         ArticleCount viewCount = new ArticleCount(article, user);
 
-        given(commentRepository.findByArticleId).willReturn(List.of(comment));
-        given(articleCountRepository.findByArticleId(article.getId())).willReturn(viewCount);
+        given(commentRepository.findByArticleId(article.getId())).willReturn(List.of(comment));
+        given(articleCountRepository.findByArticleId(article.getId())).willReturn(List.of(viewCount));
+        given(articleRepository.findById(article.getId())).willReturn(Optional.of(article));
 
         // when
         articleService.hardDeleteArticle(article.getId());
 
         // then
         verify(commentRepository).deleteAll(List.of(comment));
-        verify(articleCountRepository).delete(viewCount);
+        verify(articleCountRepository).deleteAll(List.of(viewCount));
         verify(articleRepository).deleteById(article.getId());
     }
 }

--- a/src/test/java/com/sprint5team/monew/service/article/ArticleServiceTest.java
+++ b/src/test/java/com/sprint5team/monew/service/article/ArticleServiceTest.java
@@ -235,4 +235,26 @@ public class ArticleServiceTest {
         verify(s3Storage).readArticlesFromBackup(from, to);
         verify(articleRepository).saveAll(anyList());
     }
+
+    @Test
+    void 주어진_뉴스기사_ID로_뉴스기사를_논리삭제_할_수_있다() {
+        // given
+        List<Article> articles = List.of(
+                new Article("NAVER", "https://...1", "AI", "경제", false, Instant.now(), Instant.now()),
+                new Article("한국경제", "https://...2", "AI2", "경제2", false, Instant.now(), Instant.now())
+        );
+        UUID id1 = UUID.fromString("3b98b117-369e-4c36-a44d-7eef0a341d67");
+        UUID id2 = UUID.fromString("ba4b516e-3ab3-44ae-aa9d-713d29911e50");
+        ReflectionTestUtils.setField(articles.get(0), "id", id1);
+        ReflectionTestUtils.setField(articles.get(1), "id", id2);
+
+        given(articleRepository.findById(id2)).willReturn(Optional.of(articles.get(1)));
+
+        // when
+        articleService.softDeleteArticle(id2);
+
+        // then
+        assertThat(article2.isDeleted()).isTrue();
+        verify(articleRepository).save(articles.get(1));
+    }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 뉴스 기사 물리 삭제 기능
## 🔧 주요 작업 내용
- [x] 뉴스 기사 물리 삭제 기능 추가
- [x] 해당 뉴스와 관련된 엔티티 (List<Comment>, List<ArticleCount>) 같이 삭제 
- [x] 뉴스 목록 조회 시 publishDateFrom, publishDateTo Instant -> LocalDateTime 타입 변경 

## ✅ 확인 사항
- [x] 로컬 서버에서 정상 동작 확인
- [x] 테스트 코드 작성 또는 수동 테스트 완료
- [ ] Swagger 문서 반영 확인

## 🧪 테스트 방법
- local 서버 실행 후 Postman 요청 시 정상 응답 확인, DB 데이터 제거 확인 (News, Comment, ArticleCount)

## 📎 기타 참고 사항
- 추가 논의가 필요한 사항
- 관련 이슈, API 문서 링크 등
- 뉴스 목록 조회 리팩토링도 본 PR에 포함하였습니다. 죄송합니다 😭
#48 
## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션을 준수했습니다. 
- [x] 변경 사항에 대한 테스트를 수행했습니다.
