### PR TITLE
[Feature/actuator] Actuator로 Spring Batch 작업 및 Custom metric 모니터링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,9 +65,10 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter:1.19.7'
     testImplementation 'org.testcontainers:postgresql:1.19.7'
 
-
     // Jackson Instant, LocalDateTime 등 Java 8의 시간 API 직렬화
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 // QueryDsl : 자동 생성 소스 파일 저장 위치
 def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile

--- a/src/main/java/com/sprint5team/monew/base/aop/MetricAspect.java
+++ b/src/main/java/com/sprint5team/monew/base/aop/MetricAspect.java
@@ -1,0 +1,40 @@
+package com.sprint5team.monew.base.aop;
+
+import com.sprint5team.monew.base.metric.MonewMetrics;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class MetricAspect {
+
+    private final MonewMetrics monewMetrics;
+
+    @AfterReturning("execution(* com.sprint5team.monew.domain.user.service.UserService.register(..))")
+    public void countUserCreated() {
+        monewMetrics.getUserCreatedCounter().increment();
+        monewMetrics.updateGaugeMetrics();
+    }
+
+    // 관심사 생성 성공 시 카운터 증가
+    @AfterReturning("execution(* com.sprint5team.monew.domain.interest.service.InterestService.registerInterest(..))")
+    public void countInterestCreated() {
+        monewMetrics.getInterestCreatedCounter().increment();
+        monewMetrics.updateGaugeMetrics();
+    }
+
+    // 뉴스 수집 완료 후 기사 개수 카운팅
+    @AfterReturning(
+            pointcut = "execution(* com.sprint5team.monew.domain.article.service.ArticleScraper.scrapeAll(..))",
+            returning = "xml"
+    )
+    public void countArticleCreated(Object xml) {
+        monewMetrics.updateGaugeMetrics();
+        log.debug("[s4][MetricAspect] 뉴스 기사 수 갱신 완료");
+    }
+}

--- a/src/main/java/com/sprint5team/monew/base/health/MonewHealthIndicator.java
+++ b/src/main/java/com/sprint5team/monew/base/health/MonewHealthIndicator.java
@@ -1,0 +1,52 @@
+package com.sprint5team.monew.base.health;
+
+import com.sprint5team.monew.base.service.BatchStatusService;
+import com.sprint5team.monew.domain.article.repository.ArticleRepository;
+import com.sprint5team.monew.domain.interest.repository.InterestRepository;
+import com.sprint5team.monew.domain.user.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component("monew")
+public class MonewHealthIndicator implements HealthIndicator {
+
+    private final Logger logger = LoggerFactory.getLogger(MonewHealthIndicator.class);
+
+    private final BatchStatusService  batchStatusService;
+    private final ArticleRepository articleRepository;
+    private final InterestRepository interestRepository;
+    private final UserRepository userRepository;
+
+    public MonewHealthIndicator(BatchStatusService batchStatusService, ArticleRepository articleRepository, InterestRepository interestRepository, UserRepository userRepository) {
+        this.batchStatusService = batchStatusService;
+        this.articleRepository = articleRepository;
+        this.interestRepository = interestRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public Health health() {
+        boolean lastJobSuccessful = batchStatusService.wasLastJobSuccessful();
+
+        Health.Builder builder = lastJobSuccessful ? Health.up() : Health.down();
+
+        builder.withDetail("batch", lastJobSuccessful ? "Last job success" : "Last job failed")
+                .withDetail("timestamp", batchStatusService.getLastJobTime())
+                .withDetail("successCount", batchStatusService.getSuccessCount())
+                .withDetail("failureCount", batchStatusService.getFailureCount())
+                .withDetail("totalExecutionTime", batchStatusService.getTotalExecutionTime().toString())
+                .withDetail("lastJobSuccessful", lastJobSuccessful)
+                .withDetail("totalUser", userRepository.count())
+                .withDetail("totalInterest", interestRepository.count())
+                .withDetail("totalArticle", articleRepository.count());
+
+        if (!lastJobSuccessful) {
+            builder.withDetail("lastFailureReason", batchStatusService.getLastFailureReason());
+        }
+
+        return builder.build();
+    }
+}

--- a/src/main/java/com/sprint5team/monew/base/health/MonewHealthIndicator.java
+++ b/src/main/java/com/sprint5team/monew/base/health/MonewHealthIndicator.java
@@ -4,16 +4,12 @@ import com.sprint5team.monew.base.service.BatchStatusService;
 import com.sprint5team.monew.domain.article.repository.ArticleRepository;
 import com.sprint5team.monew.domain.interest.repository.InterestRepository;
 import com.sprint5team.monew.domain.user.repository.UserRepository;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.stereotype.Component;
 
 @Component("monew")
 public class MonewHealthIndicator implements HealthIndicator {
-
-    private final Logger logger = LoggerFactory.getLogger(MonewHealthIndicator.class);
 
     private final BatchStatusService  batchStatusService;
     private final ArticleRepository articleRepository;

--- a/src/main/java/com/sprint5team/monew/base/metric/MonewMetrics.java
+++ b/src/main/java/com/sprint5team/monew/base/metric/MonewMetrics.java
@@ -1,0 +1,129 @@
+package com.sprint5team.monew.base.metric;
+
+import com.sprint5team.monew.domain.article.repository.ArticleRepository;
+import com.sprint5team.monew.domain.interest.repository.InterestRepository;
+import com.sprint5team.monew.domain.user.repository.UserRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+@Component
+@Slf4j
+public class MonewMetrics {
+
+    private final MeterRegistry meterRegistry;
+    private final ArticleRepository articleRepository;
+    private final UserRepository userRepository;
+    private final InterestRepository interestRepository;
+
+    @Getter
+    private Counter articleCreatedCounter;
+    @Getter
+    private Counter userCreatedCounter;
+    @Getter
+    private Counter interestCreatedCounter;
+
+    private final AtomicLong totalArticlesGauge = new AtomicLong(0);
+    private final AtomicLong activeUsersGauge = new AtomicLong(0);
+    private final AtomicLong totalInterestsGauge = new AtomicLong(0);
+
+
+    public MonewMetrics(MeterRegistry meterRegistry, ArticleRepository articleRepository, UserRepository userRepository, InterestRepository interestRepository) {
+        this.meterRegistry = meterRegistry;
+        this.articleRepository = articleRepository;
+        this.userRepository = userRepository;
+        this.interestRepository = interestRepository;
+    }
+
+    @PostConstruct
+    public void initMetrics() {
+
+        articleCreatedCounter = Counter.builder("monew.article.created")
+                .description("생성된 뉴스 기사 수")
+                .tag("system", "monew")
+                .register(meterRegistry);
+
+        userCreatedCounter = Counter.builder("monew.user.created")
+                .description("생성된 유저 수")
+                .tag("system", "monew")
+                .register(meterRegistry);
+
+        interestCreatedCounter = Counter.builder("monew.interest.created")
+                .description("생성된 관심사 수")
+                .tag("system", "monew")
+                .register(meterRegistry);
+
+        Gauge.builder("library.books.total", this, MonewMetrics::getTotalArticles)
+                .description("전체 뉴스 기사 수")
+                .tag("system", "monew")
+                .register(meterRegistry);
+
+        Gauge.builder("library.users.total", this, MonewMetrics::getActiveUsers)
+                .description("전체 유저 수")
+                .tag("system", "monew")
+                .register(meterRegistry);
+
+        Gauge.builder("library.interests.total", this, MonewMetrics::getTotalInterests)
+                .description("전체 관심사 수")
+                .tag("system", "monew")
+                .register(meterRegistry);
+
+    }
+
+    public double getTotalArticles() {
+        return totalArticlesGauge.get();
+    }
+
+    public double getActiveUsers() {
+        return activeUsersGauge.get();
+    }
+
+    public double getTotalInterests() {
+        return totalInterestsGauge.get();
+    }
+
+    public void updateGaugeMetrics() {
+
+        updateTotalArticles();
+        updateTotalUsers();
+        updateTotalInterests();
+
+        log.debug("[s4][MonewMetrics] 게이지 메트릭 업데이트 완료");
+    }
+
+    private void updateTotalArticles() {
+
+        try {
+            long count = articleRepository.count();
+            totalArticlesGauge.set(count);
+        } catch (Exception e) {
+            log.warn("[s4][MonewMetrics] 뉴스 기사 수 업데이트 중 오류 발생", e);
+        }
+    }
+
+    private void updateTotalUsers() {
+
+        try {
+            long count = userRepository.count();
+            activeUsersGauge.set(count);
+        } catch (Exception e) {
+            log.warn("[s4][MonewMetrics] 유저 수 업데이트 중 오류 발생", e);
+        }
+    }
+
+    private void updateTotalInterests() {
+
+        try {
+            long count = interestRepository.count();
+            totalInterestsGauge.set(count);
+        } catch (Exception e) {
+            log.warn("[s4][MonewMetrics] 관심사 수 업데이트 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/com/sprint5team/monew/base/service/BatchStatusService.java
+++ b/src/main/java/com/sprint5team/monew/base/service/BatchStatusService.java
@@ -1,0 +1,87 @@
+package com.sprint5team.monew.base.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Comparator;
+
+@Service
+@RequiredArgsConstructor
+public class BatchStatusService {
+
+    private final JobExplorer jobExplorer;
+
+    private static final String JOB_NAME = "articleScraperJob";
+
+    public boolean wasLastJobSuccessful() {
+        JobInstance lastInstance = getLastJobInstance();
+        if (lastInstance == null) return false;
+
+        JobExecution lastExecution = jobExplorer.getJobExecutions(lastInstance)
+                .stream()
+                .max(Comparator.comparing(JobExecution::getStartTime))
+                .orElse(null);
+
+        return lastExecution != null && lastExecution.getStatus() == BatchStatus.COMPLETED;
+    }
+
+
+    public Instant getLastJobTime() {
+        JobInstance lastInstance = getLastJobInstance();
+        if (lastInstance == null) return null;
+
+        return jobExplorer.getJobExecutions(lastInstance)
+                .stream()
+                .max(Comparator.comparing(JobExecution::getStartTime))
+                .map(exec -> exec.getStartTime().atZone(ZoneId.systemDefault()).toInstant())
+                .orElse(null);
+    }
+
+    public long getSuccessCount() {
+        return jobExplorer.getJobInstances(JOB_NAME, 0, Integer.MAX_VALUE).stream()
+                .flatMap(instance -> jobExplorer.getJobExecutions(instance).stream())
+                .filter(exec -> exec.getStatus() == BatchStatus.COMPLETED)
+                .count();
+    }
+
+    public long getFailureCount() {
+        return jobExplorer.getJobInstances(JOB_NAME, 0, Integer.MAX_VALUE).stream()
+                .flatMap(instance -> jobExplorer.getJobExecutions(instance).stream())
+                .filter(exec -> exec.getStatus() == BatchStatus.FAILED)
+                .count();
+    }
+
+    public Duration getTotalExecutionTime() {
+        return jobExplorer.getJobInstances(JOB_NAME, 0, Integer.MAX_VALUE).stream()
+                .flatMap(instance -> jobExplorer.getJobExecutions(instance).stream())
+                .filter(exec -> exec.getStatus() == BatchStatus.COMPLETED)
+                .map(exec -> Duration.between(
+                        exec.getStartTime().atZone(ZoneId.systemDefault()).toInstant(),
+                        exec.getEndTime().atZone(ZoneId.systemDefault()).toInstant()))
+                .reduce(Duration.ZERO, Duration::plus);
+    }
+
+    public String getLastFailureReason() {
+        return jobExplorer.getJobInstances(JOB_NAME, 0, Integer.MAX_VALUE).stream()
+                .flatMap(instance -> jobExplorer.getJobExecutions(instance).stream())
+                .filter(exec -> exec.getStatus() == BatchStatus.FAILED)
+                .max(Comparator.comparing(JobExecution::getStartTime))
+                .flatMap(exec -> exec.getAllFailureExceptions().stream().findFirst())
+                .map(Throwable::getMessage)
+                .orElse("No failure reason available");
+    }
+
+    private JobInstance getLastJobInstance() {
+        return jobExplorer.getJobInstances(JOB_NAME, 0, 1)
+                .stream()
+                .findFirst()
+                .orElse(null);
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요
- 어떤 기능을 개발했는지 간단 요약
- 예: 직원 등록 기능 구현 / 부서별 조회 API 리팩토링 등
- Spring Batch, Custom metric Actuator를 이용한 모니터링 기능 구현
## 🔧 주요 작업 내용
- [x] MonewHealthIndicator.class
  - [x] BatchStatusService.class
    - [x] 마지막 batch 작업 성공여부 수집
    - [x] job 실행 시간 수집
    - [x] 성공한 job 개수 수집
    - [x] 실패한 job 개수 수집
    - [x] 성공한 job의 total 시간 수집
  - [x] User, Article, Interest의 총 개수 수집
- [x] MonewMetrics.class
  - [x] 생성된 Article, User, Interest 수 수집
- [x] MetricAspect.class
  - [x] @AfterReturning 이용하여 User, Interest, Article 생성 시 metric count trigger  
## ✅ 확인 사항
- [x] 로컬 서버에서 정상 동작 확인
- [x] 테스트 코드 작성 또는 수동 테스트 완료
- [ ] Swagger 문서 반영 확인

## 🧪 테스트 방법
- Postman, Swagger UI 등을 통해 직접 확인한 테스트 내용
- ex: "지수 등록 API 호출 시 정상 응답 및 DB 반영 확인"
- local 서버 실행 후 ->
- http://localhost:8080/actuator/prometheus 접속
<img width="2012" height="1147" alt="스크린샷 2025-07-17 16 05 33" src="https://github.com/user-attachments/assets/3a5be490-9fa2-4779-89f9-b74330aa6f29" />
- http://localhost:8080/actuator/health/monew 접속
<img width="4024" height="2294" alt="image" src="https://github.com/user-attachments/assets/f879e39a-f08e-4c75-b6d2-f5b18b721cc1" />

## 📎 기타 참고 사항
- 추가 논의가 필요한 사항
- 관련 이슈, API 문서 링크 등
close #62 
## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션을 준수했습니다. 
- [x] 변경 사항에 대한 테스트를 수행했습니다.
