### PR TITLE
[Feature/comment] 댓글 물리 삭제 기능 구현

### DIFF
--- a/src/main/java/com/sprint5team/monew/domain/comment/controller/CommentApi.java
+++ b/src/main/java/com/sprint5team/monew/domain/comment/controller/CommentApi.java
@@ -60,7 +60,17 @@ public interface CommentApi {
             @ApiResponse(responseCode = "404",description = "댓글 정보 없음"),
             @ApiResponse(responseCode = "500",description = "서버 내부 오류")
     })
-    ResponseEntity<Void> delete(
+    ResponseEntity<Void> softDelete(
+            @Parameter(required = true,description = "댓글 ID") UUID commentId
+    );
+
+    @Operation(summary = "댓글 물리 삭제")
+    @ApiResponses(value ={
+            @ApiResponse(responseCode = "204",description = "삭제 성공"),
+            @ApiResponse(responseCode = "404",description = "댓글 정보 없음"),
+            @ApiResponse(responseCode = "500",description = "서버 내부 오류")
+    })
+    ResponseEntity<Void> hardDelete(
             @Parameter(required = true,description = "댓글 ID") UUID commentId
     );
 

--- a/src/main/java/com/sprint5team/monew/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/sprint5team/monew/domain/comment/controller/CommentController.java
@@ -56,11 +56,22 @@ public class CommentController implements CommentApi{
 
     @Override
     @DeleteMapping("/{commentId}")
-    public ResponseEntity<Void> delete(
+    public ResponseEntity<Void> softDelete(
             @PathVariable UUID commentId) {
         log.info("댓글 논리 삭제 요청: 댓글 ID = {}", commentId);
         commentService.softDelete(commentId);
         log.debug("댓글 논리 삭제 완료");
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build() ;
+    }
+
+    @Override
+    @DeleteMapping("/{commentId}/hard")
+    public ResponseEntity<Void> hardDelete(
+            @PathVariable UUID commentId) {
+        log.info("댓글 물리 삭제 요청: 댓글 ID = {}", commentId);
+        commentService.hardDelete(commentId);
+        log.debug("댓글 물리 삭제 완료");
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build() ;
     }

--- a/src/main/java/com/sprint5team/monew/domain/comment/entity/Comment.java
+++ b/src/main/java/com/sprint5team/monew/domain/comment/entity/Comment.java
@@ -53,7 +53,7 @@ public class Comment extends BaseUpdatableEntity {
         this.likeCount = likeCount;
     }
 
-    public void update(Boolean isDeleted) {
+    public void softDelete(Boolean isDeleted) {
         this.isDeleted = isDeleted;
     }
 

--- a/src/main/java/com/sprint5team/monew/domain/comment/service/CommentService.java
+++ b/src/main/java/com/sprint5team/monew/domain/comment/service/CommentService.java
@@ -17,4 +17,6 @@ public interface CommentService {
 
     void softDelete(UUID commentId);
 
+    void hardDelete(UUID commentId);
+
 }

--- a/src/main/java/com/sprint5team/monew/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/sprint5team/monew/domain/comment/service/CommentServiceImpl.java
@@ -117,7 +117,7 @@ public class CommentServiceImpl implements CommentService{
     @Override
     public void softDelete(UUID commentId) {
         Comment comment = commentRepository.findById(commentId).orElseThrow(CommentNotFoundException::new);          // 댓글 찾기, 없으면 NotfoundException
-        comment.update(true);                                                                               // 논리 삭제됨
+        comment.softDelete(true);                                                                               // 논리 삭제됨
         commentRepository.save(comment);                                                                              // 변경사항 저장
     }
 

--- a/src/main/java/com/sprint5team/monew/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/sprint5team/monew/domain/comment/service/CommentServiceImpl.java
@@ -122,6 +122,16 @@ public class CommentServiceImpl implements CommentService{
     }
 
     /**
+     * 댓글 물리 삭제 메서드
+     * @param commentId 삭제하길 원하는 댓글 ID
+     */
+    @Override
+    public void hardDelete(UUID commentId) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(CommentNotFoundException::new);          // 댓글 찾기, 없으면 NotfoundException
+        commentRepository.deleteById(commentId);
+    }
+
+    /**
      * Cursor가 CreatedAt(Instant)인지 판단하는 로직
      * @param cursor 커서
      * @return true: Instant, false: Long

--- a/src/test/java/com/sprint5team/monew/controller/comment/CommentControllerTest.java
+++ b/src/test/java/com/sprint5team/monew/controller/comment/CommentControllerTest.java
@@ -195,7 +195,7 @@ public class CommentControllerTest {
     }
 
     @Test
-    void 댓글_물리_삭제_성공(){
+    void 댓글_물리_삭제_성공() throws Exception {
         //given
         UUID commentId = UUID.randomUUID();
         willDoNothing().given(commentService).hardDelete(eq(commentId));

--- a/src/test/java/com/sprint5team/monew/controller/comment/CommentControllerTest.java
+++ b/src/test/java/com/sprint5team/monew/controller/comment/CommentControllerTest.java
@@ -194,5 +194,16 @@ public class CommentControllerTest {
                 .andExpect(status().isNoContent());
     }
 
+    @Test
+    void 댓글_물리_삭제_성공(){
+        //given
+        UUID commentId = UUID.randomUUID();
+        willDoNothing().given(commentService).hardDelete(eq(commentId));
+
+        //when && then
+        mockMvc.perform(delete("/api/comments/{commentId}/hard", commentId))
+                .andExpect(status().isNoContent());
+    }
+
 
 }

--- a/src/test/java/com/sprint5team/monew/integration/comment/CommentIntegrationTest.java
+++ b/src/test/java/com/sprint5team/monew/integration/comment/CommentIntegrationTest.java
@@ -154,6 +154,33 @@ public class CommentIntegrationTest {
                 .andExpect(status().isNoContent());
     }
 
+    @Test
+    void 댓글_물리_삭제시_DB에서_지워져야_한다() throws Exception {
+        //Given
+        UUID userId = UUID.randomUUID();
+        String content = "테스트 댓글 입니다.";
+
+        User user = new User("test@naver.com", "testname", "password1234");
+        User createdUser = userRepository.save(user);
+
+        Article article = new Article("Naver", "http://naver.com", "테스트 뉴스제목", "뉴스요약", Instant.now());
+        Article createdArticle = articleRepository.save(article);
+
+        CommentRegisterRequest request1 = new CommentRegisterRequest(createdArticle.getId(), createdUser.getId(), content+'1');
+        CommentRegisterRequest request2 = new CommentRegisterRequest(createdArticle.getId(), createdUser.getId(), content+'2');
+        CommentRegisterRequest request3 = new CommentRegisterRequest(createdArticle.getId(), createdUser.getId(), content+'3');
+
+        CommentDto commentDto1 = commentService.create(request1);
+        CommentDto commentDto2 = commentService.create(request2);
+        CommentDto commentDto3 = commentService.create(request3);
+
+        List<CommentDto> commentDtos = Arrays.asList(commentDto1, commentDto2, commentDto3);
+
+        //When && Then
+        mockMvc.perform(delete("/api/comments/{commentId}/hard",commentDto1.id()))
+                .andExpect(status().isNoContent());
+    }
+
 
 
 }

--- a/src/test/java/com/sprint5team/monew/repository/comment/CommentRepositoryTest.java
+++ b/src/test/java/com/sprint5team/monew/repository/comment/CommentRepositoryTest.java
@@ -143,4 +143,37 @@ public class CommentRepositoryTest {
         assertThat(commentList.get(2).getContent()).isEqualTo("테스트 내용1");
         assertThat(commentList.get(2).getLikeCount()).isEqualTo(1L);
     }
+
+
+    @Test
+    void 댓글_물리삭제_성공(){
+        //given
+        Article article = new Article("SRC1", "http://example.com", "Title", "Summary", Instant.now());
+        User user = new User("test@test.com", "nickname", "password");
+
+        article = articleRepository.save(article);
+        user = userRepository.save(user);
+
+        // 댓글 생성 및 저장
+        Comment save1 = commentRepository.save(createComment(article, user, "테스트 내용1"));
+        Comment save2 = commentRepository.save(createComment(article, user, "테스트 내용2"));
+        Comment save3 = commentRepository.save(createComment(article, user, "테스트 내용3"));
+
+        // 저장된 댓글에 좋아요 수 업데이트
+        save1.update(1L);   // 좋아요 1개
+        save2.update(2L);   // 좋아요 2개
+        save3.update(3L);   // 좋아요 3개
+
+        // 업데이트된 댓글 저장
+        save1 = commentRepository.save(save1);
+        save2 = commentRepository.save(save2);
+        save3 = commentRepository.save(save3);
+
+        //when
+        commentRepository.deleteById(save3.getId());    //save3 물리 삭제
+
+        //then
+        assertThat(commentRepository.findById(save3.getId())).isEmpty();
+        assertThat(commentRepository.findAll()).hasSize(2);
+    }
 }

--- a/src/test/java/com/sprint5team/monew/service/comment/CommentServiceTest.java
+++ b/src/test/java/com/sprint5team/monew/service/comment/CommentServiceTest.java
@@ -243,7 +243,7 @@ public class CommentServiceTest {
     @Test
     void 댓글_논리_삭제_성공() {
         //given
-        comment.update(true);
+        comment.softDelete(true);
         given(commentRepository.findById(eq(commentId))).willReturn(Optional.of(comment));
         given(commentRepository.save(any(Comment.class))).willReturn(comment);
 

--- a/src/test/java/com/sprint5team/monew/service/comment/CommentServiceTest.java
+++ b/src/test/java/com/sprint5team/monew/service/comment/CommentServiceTest.java
@@ -69,8 +69,8 @@ public class CommentServiceTest {
     @BeforeEach
     void setUp() {
         commentId = UUID.randomUUID();
-        article = new Article("Naver","http://naver.com/testURL","테스트 기사","테스트 기사 내용 요약", Instant.now());
-        user = new User("test@test.com","테스트 사용자","test1234");
+        article = new Article("Naver", "http://naver.com/testURL", "테스트 기사", "테스트 기사 내용 요약", Instant.now());
+        user = new User("test@test.com", "테스트 사용자", "test1234");
         createdAt = Instant.now();
         content = "테스트 댓글";
         comment = new Comment(article, user, content);
@@ -80,7 +80,7 @@ public class CommentServiceTest {
     }
 
     @Test
-    void 댓글_생성_성공_테스트(){
+    void 댓글_생성_성공_테스트() {
         //given
         CommentRegisterRequest request = new CommentRegisterRequest(article.getId(), user.getId(), content);
         given(articleRepository.findById(article.getId())).willReturn(Optional.of(article));
@@ -100,7 +100,7 @@ public class CommentServiceTest {
     }
 
     @Test
-    void 댓글_생성_실패_존재하지않는_게시글(){
+    void 댓글_생성_실패_존재하지않는_게시글() {
         //given
         CommentRegisterRequest request = new CommentRegisterRequest(article.getId(), user.getId(), content);
         given(articleRepository.findById(article.getId())).willReturn(Optional.empty());
@@ -117,7 +117,7 @@ public class CommentServiceTest {
     }
 
     @Test
-    void 댓글_페이지네이션을_사용한_생성일자순_조회_성공(){
+    void 댓글_페이지네이션을_사용한_생성일자순_조회_성공() {
         // given
         int pageSize = 3; // 페이지 크기를 3으로 설정, 실제로는 2개의 검색만 보이게 할 것임.
         Instant createdAt = Instant.now();
@@ -128,9 +128,9 @@ public class CommentServiceTest {
         Comment comment2 = new Comment(article, user, content + "2");
         Comment comment3 = new Comment(article, user, content + "3");
 
-        comment1.update((long)1);
-        comment2.update((long)2);
-        comment3.update((long)3);
+        comment1.update((long) 1);
+        comment2.update((long) 2);
+        comment3.update((long) 3);
 
         ReflectionTestUtils.setField(comment1, "id", UUID.randomUUID());
         ReflectionTestUtils.setField(comment2, "id", UUID.randomUUID());
@@ -180,7 +180,7 @@ public class CommentServiceTest {
 
 
         // 첫 페이지 결과 세팅 (2개 메시지)
-        List<Comment> firstPageComments = List.of(comment1, comment2,comment3);
+        List<Comment> firstPageComments = List.of(comment1, comment2, comment3);
         List<CommentDto> firstPageDtos = List.of(commentDto1, commentDto2);
 
         // 첫 페이지는 다음 페이지가 있고, 커서는 comment2의 생성 시간이어야 함
@@ -188,20 +188,20 @@ public class CommentServiceTest {
                 firstPageDtos,
                 message3CreatedAt.toString(),
                 message3CreatedAt,
-                pageSize-1,
+                pageSize - 1,
                 3L,
                 true
         );
 
         given(commentRepository.countTotalElements(any()))
                 .willReturn(3L);
-        given(commentRepository.findCommentsWithCursor(eq(article.getId()),eq(createdAt.toString()),eq(createdAt),any(Pageable.class)))
+        given(commentRepository.findCommentsWithCursor(eq(article.getId()), eq(createdAt.toString()), eq(createdAt), any(Pageable.class)))
                 .willReturn(firstPageComments);
         given(commentMapper.toDto(eq(comment1))).willReturn(commentDto1);
         given(commentMapper.toDto(eq(comment2))).willReturn(commentDto2);
 
         // when
-        CursorPageResponseCommentDto result = commentService.find(article.getId(),createdAt.toString(),createdAt,pageable);
+        CursorPageResponseCommentDto result = commentService.find(article.getId(), createdAt.toString(), createdAt, pageable);
 
         // then
         assertThat(result).isEqualTo(firstPageResponse);
@@ -217,7 +217,7 @@ public class CommentServiceTest {
                 secondPageDtos,
                 null,
                 null,
-                pageSize-1,
+                pageSize - 1,
                 3L,
                 false
         );
@@ -226,7 +226,7 @@ public class CommentServiceTest {
         // 두 번째 페이지 모의 객체 설정
         given(commentRepository.countTotalElements(eq(article.getId())))
                 .willReturn(3L);
-        given(commentRepository.findCommentsWithCursor(eq(article.getId()), eq(firstPageResponse.nextCursor()),eq(firstPageResponse.nextAfter()), any(Pageable.class)))
+        given(commentRepository.findCommentsWithCursor(eq(article.getId()), eq(firstPageResponse.nextCursor()), eq(firstPageResponse.nextAfter()), any(Pageable.class)))
                 .willReturn(secondPageMessages);
         given(commentMapper.toDto(eq(comment3))).willReturn(commentDto3);
 
@@ -241,7 +241,7 @@ public class CommentServiceTest {
     }
 
     @Test
-    void 댓글_논리_삭제_성공(){
+    void 댓글_논리_삭제_성공() {
         //given
         comment.update(true);
         given(commentRepository.findById(eq(commentId))).willReturn(Optional.of(comment));
@@ -257,7 +257,7 @@ public class CommentServiceTest {
     }
 
     @Test
-    void 댓글_논리_삭제_실패_존재하지않는_댓글() {
+    void 댓글_논리_삭제_실패_존재하지않는_댓글ID() {
         //given
         given(commentRepository.findById(eq(commentId))).willReturn(Optional.empty());
 
@@ -265,4 +265,31 @@ public class CommentServiceTest {
         assertThatThrownBy(() -> commentService.softDelete(commentId))
                 .isInstanceOf(CommentNotFoundException.class);
     }
+
+    @Test
+    void 댓글_물리_삭제_성공(){
+        //given
+        given(commentRepository.findById(eq(commentId))).willReturn(Optional.of(comment));
+
+        //when
+        commentService.hardDelete(commentId);
+
+        //then
+        verify(commentRepository).findById(eq(commentId));
+        verify(commentRepository).deleteById(eq(commentId));
+    }
+
+
+    @Test
+    void 댓글_물리_삭제_실패_존재하지않는_댓글_ID(){
+        //given
+        given(commentRepository.findById(eq(commentId))).willReturn(Optional.empty());
+
+        //when && then
+        assertThatThrownBy(() -> commentService.hardDelete(commentId))
+                .isInstanceOf(CommentNotFoundException.class);
+
+    }
+
+
 }


### PR DESCRIPTION
## 📌 작업 개요
- 어떤 기능을 개발했는지 간단 요약
- 댓글 물리 삭제 구현 

## 🔧 주요 작업 내용
- [x] 댓글 물리 삭제 테스트 코드 추가
- [x] 댓글 물리 삭제 API 추가
- [x] 댓글 물리 삭제 서비스 로직 추가
- [x] 댓글 물리 삭제 통합 테스트 추가
- [x] Postman을 통한 테스트 
- [x] 피드백을 반영하여 Comment Entity의 논리삭제 메서드명을 update 에서 softDelete로 수정  

## ✅ 확인 사항
- [x] 로컬 서버에서 정상 동작 확인
- [x] 테스트 코드 작성 또는 수동 테스트 완료
- [x] Swagger 문서 반영 확인

## 🧪 테스트 방법
- Postman, Swagger UI 등을 통해 직접 확인한 테스트 내용
- #65
<img width="1598" height="656" alt="image" src="https://github.com/user-attachments/assets/3596bc2a-d631-4dba-b23e-c12aca6e6026" />


## 📎 기타 참고 사항
- 추가 논의가 필요한 사항
- 관련 이슈, API 문서 링크 등

## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션을 준수했습니다. 
- [x] 변경 사항에 대한 테스트를 수행했습니다.
