### PR TITLE
[Bugfix/comment] 로컬에서 댓글 조회시 500에러 발생하는 버그 수정

### DIFF
--- a/src/main/java/com/sprint5team/monew/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/sprint5team/monew/domain/comment/controller/CommentController.java
@@ -43,7 +43,7 @@ public class CommentController implements CommentApi{
             @RequestParam(required = false) String cursor,
             @RequestParam Integer limit,
             @RequestParam(required = false) Instant after,
-            @RequestParam UUID userId
+            @RequestHeader("MoNew-Request-User-ID") UUID userId
     ) {
         log.info("댓글 조회 요청: 기사 ID={}, 요청자 ID={}, 커서={}",articleId, userId, cursor);
         Pageable pageable = PageRequest.of(0, limit+1, Sort.Direction.valueOf(direction), orderBy, "createdAt");

--- a/src/main/java/com/sprint5team/monew/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/sprint5team/monew/domain/comment/service/CommentServiceImpl.java
@@ -74,7 +74,12 @@ public class CommentServiceImpl implements CommentService{
         Long totalElements = commentRepository.countTotalElements(articleId);
 
         //커서게산을 위한 lastIndex 검색 로직 (페이징할때 원하는 사이즈보다 1 더 큰 사이즈를 가져와서 마지막인덱스를 커서로 사용하기 위함)
-        Comment lastIndex = commentList.get(commentList.size() - 1);
+        Comment lastIndex = null;
+
+        if(!commentList.isEmpty()) {
+            lastIndex = commentList.get(commentList.size() - 1);
+        }
+
         String nextCursor = null;
         Instant afterCursor = null;
 

--- a/src/test/java/com/sprint5team/monew/controller/comment/CommentControllerTest.java
+++ b/src/test/java/com/sprint5team/monew/controller/comment/CommentControllerTest.java
@@ -171,7 +171,7 @@ public class CommentControllerTest {
                         .param("limit","10")
                         .param("articleId",articleId.toString())
                         .param("cursor",cursor.toString())
-                        .param("userId",userId.toString()))
+                        .header("MoNew-Request-User-ID", userId.toString()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content").isArray())
                 .andExpect(jsonPath("$.nextCursor").isEmpty())

--- a/src/test/java/com/sprint5team/monew/integration/comment/CommentIntegrationTest.java
+++ b/src/test/java/com/sprint5team/monew/integration/comment/CommentIntegrationTest.java
@@ -116,7 +116,7 @@ public class CommentIntegrationTest {
                         .param("orderBy", "createdAt")
                         .param("direction","ASC")
                         .param("limit","10")
-                        .param("userId",userId.toString()))
+                        .header("MoNew-Request-User-ID", userId.toString()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content", hasSize(3)))
                 .andExpect(jsonPath("$.content[0].content").value("테스트 댓글 입니다.1"))


### PR DESCRIPTION
## 📌 작업 개요
- 어떤 기능을 개발했는지 간단 요약
- 예: 직원 등록 기능 구현 / 부서별 조회 API 리팩토링 등

## 🔧 주요 작업 내용
- [x] CommentController의 UserId @RequestParam 에서 @RequestHeader로 변경
- [x] CommentServiceImpl의 find 메서드의 lastIndex 검색로직에 댓글갯수가 0일때 발생하는 오류 수정
- [x] 테스트코드에 위의 변경사항 반영

## ✅ 확인 사항
- [x] 로컬 서버에서 정상 동작 확인
- [x] 테스트 코드 작성 또는 수동 테스트 완료
- [x] Swagger 문서 반영 확인

## 🧪 테스트 방법
- Postman, Swagger UI 등을 통해 직접 확인한 테스트 내용

## 📎 기타 참고 사항
- 추가 논의가 필요한 사항
- 관련 이슈, API 문서 링크 등

## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션을 준수했습니다. 
- [x] 변경 사항에 대한 테스트를 수행했습니다.
