### PR TITLE
[Feature/notification] 알림 등록 기능 - 댓글 좋아요

### DIFF
--- a/src/main/java/com/sprint5team/monew/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/sprint5team/monew/domain/comment/service/CommentServiceImpl.java
@@ -14,18 +14,17 @@ import com.sprint5team.monew.domain.comment.mapper.CommentMapper;
 import com.sprint5team.monew.domain.comment.mapper.LikeMapper;
 import com.sprint5team.monew.domain.comment.repository.CommentRepository;
 import com.sprint5team.monew.domain.comment.repository.LikeRepository;
+import com.sprint5team.monew.domain.notification.service.NotificationService;
 import com.sprint5team.monew.domain.user.entity.User;
 import com.sprint5team.monew.domain.user.exception.UserNotFoundException;
 import com.sprint5team.monew.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.crossstore.ChangeSetPersister;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
-import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -41,6 +40,7 @@ public class CommentServiceImpl implements CommentService{
     private final CommentMapper commentMapper;
     private final LikeRepository likeRepository;
     private final LikeMapper likeMapper;
+    private final NotificationService notificationService;
 
     /**
      * 댓글을 생성하는 메소드
@@ -180,6 +180,10 @@ public class CommentServiceImpl implements CommentService{
         likeRepository.save(like);
         comment.update(comment.getLikeCount() + 1);
         commentRepository.save(comment);
+
+        if (!comment.getUser().getId().equals(userId)) {
+            notificationService.notifyCommentLiked(comment.getUser().getId(), comment.getId(), user.getNickname());
+        }
 
         return likeMapper.toDto(like);
     }

--- a/src/main/java/com/sprint5team/monew/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/sprint5team/monew/domain/notification/controller/NotificationController.java
@@ -22,7 +22,7 @@ public class NotificationController {
     public ResponseEntity<CursorPageResponseNotificationDto> findAllNotConfirmed(
             @RequestParam(required = false) String cursor,
             @RequestParam(required = false) Instant after,
-            @RequestParam(defaultValue = "10") int limit,
+            @RequestParam Integer limit,
             @RequestHeader("Monew-Request-User-ID") UUID userId
     ) {
         CursorPageResponseNotificationDto response =  notificationService.getAllNotifications(userId, cursor, after, limit);

--- a/src/main/java/com/sprint5team/monew/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint5team/monew/domain/notification/service/NotificationServiceImpl.java
@@ -69,7 +69,7 @@ public class NotificationServiceImpl implements NotificationService {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
 
-        String content = likerName + "님이 내 댓글을 좋아했습니다.";
+        String content = String.format("[%s]님이 나의 댓글을 좋아합니다.", likerName);
 
         Notification notification = Notification.builder()
                 .user(user)

--- a/src/main/java/com/sprint5team/monew/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint5team/monew/domain/notification/service/NotificationServiceImpl.java
@@ -110,7 +110,7 @@ public class NotificationServiceImpl implements NotificationService {
                 dtoList,
                 nextCursor,
                 nextAfter,
-                dtoList.size(),
+                limit,
                 totalElements,
                 hasNext
         );


### PR DESCRIPTION
## 📌 작업 개요
- 내가 작성한 댓글에 좋아요가 눌리면 알림이 생성됩니다.
    - 내용: `[사용자]님이 나의 댓글을 좋아합니다.`
    - 관련 리소스 정보: 댓글
    - #103 
## 🔧 주요 작업 내용
- [x] CommentServiceImpl 의 like 메서드 안에 notificationService의 notifyCommentLiked 메서드 호출
- [x] 전체/단일 알림 확인 후 새로운 알림이 알림창을 열어도 보이지 않던 문제 확인
- [x] 동시(짧은 1초내 여러 알림) 알림 생성 시 모든 알림이 db에 반영이 되었으나 화면에 마지막 건만 보이던 문제 확인
- [x] 알림 응답의 size가 0으로 반환되던 문제 수정

## ✅ 확인 사항
- [x] 로컬 서버에서 정상 동작 확인
- [ ] 테스트 코드 작성 또는 수동 테스트 완료
- [ ] Swagger 문서 반영 확인

## 🧪 테스트 방법
-로컬 (localhost:8080) 실행 후 유저2개로 테스트 진행
<img width="1449" height="454" alt="image" src="https://github.com/user-attachments/assets/efb1669f-353e-4622-a93b-8738738af5f8" />


## 📎 기타 참고 사항
- 댓글에 좋아요 누르고 새로고침 후 다시 좋아요 취소 불가능한 문제(409 오류) - 공유 완료
- 관련 이슈, API 문서 링크 등
- 알림 목록 조회 - 버그 수정 과정 - https://www.notion.so/ohgiraffers/238649136c1180b7a775c23b61c44a24?source=copy_link

## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션을 준수했습니다. 
- [ ] 변경 사항에 대한 테스트를 수행했습니다.
