### PR TITLE
[Bugfix/article] 뉴스 기사 목록 조회 댓글 수 정렬

### DIFF
--- a/src/main/java/com/sprint5team/monew/domain/article/repository/ArticleCustomRepositoryImpl.java
+++ b/src/main/java/com/sprint5team/monew/domain/article/repository/ArticleCustomRepositoryImpl.java
@@ -99,9 +99,12 @@ public class ArticleCustomRepositoryImpl implements ArticleCustomRepository {
                         .leftJoin(comment).on(comment.article.eq(article))
                         .where(builder)
                         .groupBy(article.id)
-                        .orderBy(direction == Order.ASC
-                                ? comment.count().asc()
-                                : comment.count().desc())
+                        .orderBy(
+                                direction == Order.ASC
+                                        ? comment.count().asc().nullsLast() : comment.count().desc().nullsLast(),
+                                direction == Order.ASC
+                                        ? article.createdAt.asc() : article.createdAt.desc()
+                        )
                         .limit(filter.limit() + 1)
                         .fetch();
 


### PR DESCRIPTION
## 📌 작업 개요
- 어떤 기능을 개발했는지 간단 요약
- 뉴스 기사 목록 조회 댓글 수 정렬 시 페이지네이션이 되지 않는 문제 리팩토링

## 🔧 주요 작업 내용
- [x] ArticleCustomRepository.findByCursorFilter()
  - 댓글 수 정렬 쿼리 .orderBy()절 수정 

## ✅ 확인 사항
- [x] 로컬 서버에서 정상 동작 확인
- [x] 테스트 코드 작성 또는 수동 테스트 완료
- [ ] Swagger 문서 반영 확인

## 🧪 테스트 방법
- Postman, Swagger UI 등을 통해 직접 확인한 테스트 내용
- ex: "지수 등록 API 호출 시 정상 응답 및 DB 반영 확인"

## 📎 기타 참고 사항
- 추가 논의가 필요한 사항
- 관련 이슈, API 문서 링크 등

## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션을 준수했습니다. 
- [x] 변경 사항에 대한 테스트를 수행했습니다.
